### PR TITLE
Add implementation of basic traits for FixError

### DIFF
--- a/src/gtin12/mod.rs
+++ b/src/gtin12/mod.rs
@@ -3,7 +3,7 @@
 use utils;
 
 /// Errors that make GTIN-12 correction impossible.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FixError {
     /// The provided string contains non-ASCII characters.
     NonAsciiString,

--- a/src/gtin13/mod.rs
+++ b/src/gtin13/mod.rs
@@ -3,7 +3,7 @@
 use utils;
 
 /// Errors that make GTIN-13 correction impossible.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FixError {
     /// The provided string contains non-ASCII characters.
     NonAsciiString,

--- a/src/gtin14/mod.rs
+++ b/src/gtin14/mod.rs
@@ -3,7 +3,7 @@
 use utils;
 
 /// Errors that make GTIN-14 correction impossible.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FixError {
     /// The provided string contains non-ASCII characters.
     NonAsciiString,

--- a/src/gtin8/mod.rs
+++ b/src/gtin8/mod.rs
@@ -3,7 +3,7 @@
 use utils;
 
 /// Errors that make GTIN-8 correction impossible.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FixError {
     /// The provided string contains non-ASCII characters.
     NonAsciiString,


### PR DESCRIPTION
Using the derive macro, Clone, Copy, PartialEq, Eq and Hash
are implemented for the FixError types.