### PR TITLE
Implement Error trait for FixError

### DIFF
--- a/src/gtin12/mod.rs
+++ b/src/gtin12/mod.rs
@@ -1,5 +1,7 @@
 //! Performs validation and correction of GTIN-12 and UPC-A codes.
 
+use std::error::Error;
+use std::fmt;
 use utils;
 
 /// Errors that make GTIN-12 correction impossible.
@@ -11,6 +13,23 @@ pub enum FixError {
     TooLong,
     /// The calculated check-digit did not match the code's check-digit.
     CheckDigitIncorrect,
+}
+
+impl Error for FixError {}
+
+impl fmt::Display for FixError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FixError::NonAsciiString => {
+                write!(f, "the provided string contains non-ASCII characters")
+            }
+            FixError::TooLong => write!(f, "the provided code was too long too be valid"),
+            FixError::CheckDigitIncorrect => write!(
+                f,
+                "the calculated check-digit did not match the code's check-digit"
+            ),
+        }
+    }
 }
 
 /// Check that a UPC-A code is valid by confirming that it is made of

--- a/src/gtin13/mod.rs
+++ b/src/gtin13/mod.rs
@@ -1,5 +1,7 @@
 //! Performs validation and correction of GTIN-13 and EAN-13 codes.
 
+use std::error::Error;
+use std::fmt;
 use utils;
 
 /// Errors that make GTIN-13 correction impossible.
@@ -11,6 +13,23 @@ pub enum FixError {
     TooLong,
     /// The calculated check-digit did not match the code's check-digit.
     CheckDigitIncorrect,
+}
+
+impl Error for FixError {}
+
+impl fmt::Display for FixError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FixError::NonAsciiString => {
+                write!(f, "the provided string contains non-ASCII characters")
+            }
+            FixError::TooLong => write!(f, "the provided code was too long too be valid"),
+            FixError::CheckDigitIncorrect => write!(
+                f,
+                "the calculated check-digit did not match the code's check-digit"
+            ),
+        }
+    }
 }
 
 /// Check that a GTIN-13 code is valid by checking the length (should be
@@ -151,7 +170,6 @@ mod tests {
     fn fix_non_ascii() {
         assert!(fix("❤").is_err());
     }
-
 
     #[test]
     fn fix_too_long() {

--- a/src/gtin14/mod.rs
+++ b/src/gtin14/mod.rs
@@ -1,5 +1,7 @@
 //! Performs validation and correction of GTIN-14 codes.
 
+use std::error::Error;
+use std::fmt;
 use utils;
 
 /// Errors that make GTIN-14 correction impossible.
@@ -11,6 +13,23 @@ pub enum FixError {
     TooLong,
     /// The calculated check-digit did not match the code's check-digit.
     CheckDigitIncorrect,
+}
+
+impl Error for FixError {}
+
+impl fmt::Display for FixError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FixError::NonAsciiString => {
+                write!(f, "the provided string contains non-ASCII characters")
+            }
+            FixError::TooLong => write!(f, "the provided code was too long too be valid"),
+            FixError::CheckDigitIncorrect => write!(
+                f,
+                "the calculated check-digit did not match the code's check-digit"
+            ),
+        }
+    }
 }
 
 /// Check that a GTIN-14 code is valid by confirming that it is exactly

--- a/src/gtin8/mod.rs
+++ b/src/gtin8/mod.rs
@@ -1,5 +1,7 @@
 //! Performs validation and correction of GTIN-8 codes.
 
+use std::error::Error;
+use std::fmt;
 use utils;
 
 /// Errors that make GTIN-8 correction impossible.
@@ -11,6 +13,23 @@ pub enum FixError {
     TooLong,
     /// The calculated check-digit did not match the code's check-digit.
     CheckDigitIncorrect,
+}
+
+impl Error for FixError {}
+
+impl fmt::Display for FixError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FixError::NonAsciiString => {
+                write!(f, "the provided string contains non-ASCII characters")
+            }
+            FixError::TooLong => write!(f, "the provided code was too long too be valid"),
+            FixError::CheckDigitIncorrect => write!(
+                f,
+                "the calculated check-digit did not match the code's check-digit"
+            ),
+        }
+    }
 }
 
 /// Check that a GTIN-8 code is valid by confirming that it is exactly


### PR DESCRIPTION
Was suggested by a comment in a [closed feature request](https://github.com/austinhartzheim/rust-gtin-validate/issues/5#issuecomment-1374391969).

I used `rustfmt` on it, so there was a minor change in an unrelated file.